### PR TITLE
Update IAM permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,7 @@ See [KMS](./docs/kms.md) docs for helper material on producing the required KMS 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.34.0 |
-
-## Modules
-
-No modules.
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.33 |
 
 ## Resources
 
@@ -102,14 +98,22 @@ No modules.
 | [google_compute_region_health_check.vault_hc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_health_check) | resource |
 | [google_compute_region_instance_group_manager.vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager) | resource |
 | [google_dns_record_set.vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
+| [google_kms_crypto_key_iam_member.vault_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
+| [google_project_iam_custom_role.vault_custom_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_custom_role.vault_kms_custom_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.vault_custom_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.vault_iam](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.vault_iam_kms](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_account.vault_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_storage_bucket_iam_binding.snapshots_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
+| [google_storage_bucket_iam_binding.snapshots_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 | [google_compute_network.network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network) | data source |
 | [google_compute_subnetwork.subnetwork](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 | [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
 | [google_dns_managed_zone.vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/dns_managed_zone) | data source |
+| [google_kms_crypto_key.vault_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/kms_crypto_key) | data source |
+| [google_kms_key_ring.vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/kms_key_ring) | data source |
 | [google_netblock_ip_ranges.legacy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/netblock_ip_ranges) | data source |
 | [google_netblock_ip_ranges.new](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/netblock_ip_ranges) | data source |
 
@@ -117,60 +121,72 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | (required) The project ID to host the cluster in (required) | `string` | n/a | yes |
+| <a name="input_vault_fqdn"></a> [vault\_fqdn](#input\_vault\_fqdn) | Fully qualified domain name to use for joining peer nodes and optionally DNS | `string` | n/a | yes |
+| <a name="input_vault_license_sm_secret_name"></a> [vault\_license\_sm\_secret\_name](#input\_vault\_license\_sm\_secret\_name) | Name of Secret Manager secret containing Vault license. | `string` | n/a | yes |
+| <a name="input_vault_snapshot_gcs_bucket_name"></a> [vault\_snapshot\_gcs\_bucket\_name](#input\_vault\_snapshot\_gcs\_bucket\_name) | Name of Google Cloud Storage bucket to hold Vault snapshots | `string` | n/a | yes |
+| <a name="input_vault_tls_ca_bundle_sm_secret_name"></a> [vault\_tls\_ca\_bundle\_sm\_secret\_name](#input\_vault\_tls\_ca\_bundle\_sm\_secret\_name) | Name of Secret Manager containing Vault TLS custom CA bundle. | `string` | n/a | yes |
+| <a name="input_vault_tls_cert_sm_secret_name"></a> [vault\_tls\_cert\_sm\_secret\_name](#input\_vault\_tls\_cert\_sm\_secret\_name) | Name of Secret Manager containing Vault TLS certificate. | `string` | n/a | yes |
+| <a name="input_vault_tls_privkey_sm_secret_name"></a> [vault\_tls\_privkey\_sm\_secret\_name](#input\_vault\_tls\_privkey\_sm\_secret\_name) | Name of Secret Manager containing Vault TLS private key. | `string` | n/a | yes |
+| <a name="input_additional_package_names"></a> [additional\_package\_names](#input\_additional\_package\_names) | List of additional repository package names to install | `set(string)` | `[]` | no |
 | <a name="input_application_prefix"></a> [application\_prefix](#input\_application\_prefix) | (optional) The prefix to give to cloud entities | `string` | `"vault"` | no |
 | <a name="input_auto_join_tag"></a> [auto\_join\_tag](#input\_auto\_join\_tag) | (optional) A list of a tag which will be used by Vault to join other nodes to the cluster. If left blank, the module will use the first entry in `tags` | `list(string)` | `null` | no |
-| <a name="input_cidr_ingress_https_allow"></a> [cidr\_ingress\_https\_allow](#input\_cidr\_ingress\_https\_allow) | CIDR ranges to allow HTTPS traffic inbound to Vault instance(s). | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_boot_disk_size"></a> [boot\_disk\_size](#input\_boot\_disk\_size) | (optional) The disk size (GB) to use to create the boot disk | `number` | `30` | no |
+| <a name="input_boot_disk_type"></a> [boot\_disk\_type](#input\_boot\_disk\_type) | (optional) The disk type to use to create the boot disk | `string` | `"pd-balanced"` | no |
+| <a name="input_cidr_ingress_https_allow"></a> [cidr\_ingress\_https\_allow](#input\_cidr\_ingress\_https\_allow) | CIDR ranges to allow HTTPS traffic inbound to Vault instance(s). | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_cloud_dns_managed_zone"></a> [cloud\_dns\_managed\_zone](#input\_cloud\_dns\_managed\_zone) | Zone name to create TFE Cloud DNS record in if `create_cloud_dns_record` is set to `true`. | `string` | `null` | no |
 | <a name="input_common_labels"></a> [common\_labels](#input\_common\_labels) | (optional) Common labels to apply to GCP resources. | `map(string)` | `{}` | no |
 | <a name="input_compute_image_family"></a> [compute\_image\_family](#input\_compute\_image\_family) | (optional) The family name of the image, https://cloud.google.com/compute/docs/images/os-details,defaults to `Ubuntu` | `string` | `"ubuntu-2204-lts"` | no |
 | <a name="input_compute_image_project"></a> [compute\_image\_project](#input\_compute\_image\_project) | (optional) The project name of the image, https://cloud.google.com/compute/docs/images/os-details, defaults to `Ubuntu` | `string` | `"ubuntu-os-cloud"` | no |
-| <a name="input_create_cloud_dns_record"></a> [create\_cloud\_dns\_record](#input\_create\_cloud\_dns\_record) | Boolean to create Google Cloud DNS record for `vault_leader_tls_servername` resolving to load balancer IP. `cloud_dns_managed_zone` is required when `true`. | `bool` | `false` | no |
+| <a name="input_create_cloud_dns_record"></a> [create\_cloud\_dns\_record](#input\_create\_cloud\_dns\_record) | Boolean to create Google Cloud DNS record for `vault_fqdn` resolving to load balancer IP. `cloud_dns_managed_zone` is required when `true`. | `bool` | `false` | no |
 | <a name="input_debug"></a> [debug](#input\_debug) | [Optional bool] Enable additional outputs available module outputs for debug purposes. | `bool` | `false` | no |
-| <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | (optional) The disk size (GB) to use to create the disk | `number` | `100` | no |
-| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | (optional) The disk type to use to create the disk | `string` | `"pd-ssd"` | no |
 | <a name="input_enable_auto_healing"></a> [enable\_auto\_healing](#input\_enable\_auto\_healing) | (optional) Enable auto-healing on the Instance Group | `bool` | `false` | no |
 | <a name="input_enable_iap"></a> [enable\_iap](#input\_enable\_iap) | (Optional bool) Enable https://cloud.google.com/iap/docs/using-tcp-forwarding#console, defaults to `true`. | `bool` | `true` | no |
-| <a name="input_gcp_kms_crypto_key"></a> [gcp\_kms\_crypto\_key](#input\_gcp\_kms\_crypto\_key) | (optional) The name of the KMS crypto key | `string` | `"vault-key"` | no |
-| <a name="input_gcp_kms_key_ring"></a> [gcp\_kms\_key\_ring](#input\_gcp\_kms\_key\_ring) | (optional) The name of the KMS key ring | `string` | `"vault"` | no |
+| <a name="input_gcp_kms_crypto_key"></a> [gcp\_kms\_crypto\_key](#input\_gcp\_kms\_crypto\_key) | (optional) The name of the KMS crypto key | `string` | `null` | no |
+| <a name="input_gcp_kms_key_ring"></a> [gcp\_kms\_key\_ring](#input\_gcp\_kms\_key\_ring) | (optional) The name of the KMS key ring if it exists | `string` | `null` | no |
 | <a name="input_gcp_kms_project"></a> [gcp\_kms\_project](#input\_gcp\_kms\_project) | (optional) The project the KMS key ring is in. Can be left blank if project is the same as provider | `string` | `null` | no |
 | <a name="input_gcp_kms_region"></a> [gcp\_kms\_region](#input\_gcp\_kms\_region) | (optional) The region the KMS key ring is in. Can be left blank if region is the same as main region | `string` | `null` | no |
-| <a name="input_google_service_account_iam_roles"></a> [google\_service\_account\_iam\_roles](#input\_google\_service\_account\_iam\_roles) | (optional) List of IAM roles to give to the Vault service account | `list(string)` | <pre>[<br>  "roles/compute.viewer",<br>  "roles/secretmanager.secretAccessor",<br>  "roles/cloudkms.cryptoKeyEncrypterDecrypter"<br>]</pre> | no |
+| <a name="input_google_service_account_iam_roles"></a> [google\_service\_account\_iam\_roles](#input\_google\_service\_account\_iam\_roles) | (optional) List of IAM roles to give to the Vault service account | `list(string)` | <pre>[<br/>  "roles/secretmanager.secretAccessor",<br/>  "roles/logging.logWriter",<br/>  "roles/monitoring.metricWriter"<br/>]</pre> | no |
 | <a name="input_health_check_interval"></a> [health\_check\_interval](#input\_health\_check\_interval) | (optional) How often, in seconds, to send a health check | `number` | `30` | no |
 | <a name="input_health_timeout"></a> [health\_timeout](#input\_health\_timeout) | (optional) How long, in seconds, to wait before claiming failure | `number` | `15` | no |
 | <a name="input_initial_auto_healing_delay"></a> [initial\_auto\_healing\_delay](#input\_initial\_auto\_healing\_delay) | (optional) The time, in seconds, that the managed instance group waits before it applies autohealing policies | `number` | `1200` | no |
 | <a name="input_load_balancing_scheme"></a> [load\_balancing\_scheme](#input\_load\_balancing\_scheme) | (optional) Type of load balancer to use (INTERNAL, EXTERNAL, or NONE) | `string` | `"INTERNAL"` | no |
-| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | (optional) The machine type to use for the Vault nodes | `string` | `"e2-standard-2"` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | (optional) The machine type to use for the Vault nodes | `string` | `"n2-standard-2"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | (optional) Metadata to add to the Compute Instance template | `map(string)` | `null` | no |
 | <a name="input_network"></a> [network](#input\_network) | (optional) The VPC network to host the cluster in | `string` | `"default"` | no |
 | <a name="input_network_project_id"></a> [network\_project\_id](#input\_network\_project\_id) | (optional) The project that the VPC network lives in. Can be left blank if network is in the same project as provider | `string` | `null` | no |
 | <a name="input_network_region"></a> [network\_region](#input\_network\_region) | (optional) The region that the VPC network lives in. Can be left blank if network is in the same region as provider | `string` | `null` | no |
 | <a name="input_node_count"></a> [node\_count](#input\_node\_count) | (optional) The number of nodes to create in the pool | `number` | `6` | no |
 | <a name="input_packer_image"></a> [packer\_image](#input\_packer\_image) | (optional) The packer image to use | `string` | `null` | no |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | (required) The project ID to host the cluster in (required) | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | (optional) The region to host the cluster in | `string` | `"us-central1"` | no |
-| <a name="input_skip_install_tools"></a> [skip\_install\_tools](#input\_skip\_install\_tools) | (optional) Skips installing required packages (unzip, jq, wget) | `bool` | `false` | no |
 | <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | (optional) The subnet in the VPC network to host the cluster in | `string` | `"default"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | (optional) A list containing tags to assign to all resources | `list(string)` | <pre>[<br>  "vault"<br>]</pre> | no |
-| <a name="input_vault_api_port"></a> [vault\_api\_port](#input\_vault\_api\_port) | (optional) The port the Vault API will listen on | `string` | `"8200"` | no |
-| <a name="input_vault_backend_storage"></a> [vault\_backend\_storage](#input\_vault\_backend\_storage) | (optional) The backend storage type to use, defaults to consul | `string` | `"integrated"` | no |
-| <a name="input_vault_bin_directory"></a> [vault\_bin\_directory](#input\_vault\_bin\_directory) | (optional) The bin directory for the Vault binary | `string` | `"/usr/bin"` | no |
-| <a name="input_vault_ca_bundle_secret"></a> [vault\_ca\_bundle\_secret](#input\_vault\_ca\_bundle\_secret) | (required) The name of the CA bundle secret in Secret Manager | `string` | n/a | yes |
-| <a name="input_vault_cluster_port"></a> [vault\_cluster\_port](#input\_vault\_cluster\_port) | (optional) The port the Vault cluster port will listen on | `string` | `"8201"` | no |
-| <a name="input_vault_data_directory"></a> [vault\_data\_directory](#input\_vault\_data\_directory) | (optional) The data directory for the Vault raft data | `string` | `"/opt/vault"` | no |
+| <a name="input_systemd_dir"></a> [systemd\_dir](#input\_systemd\_dir) | Path to systemd directory for unit files | `string` | `"/lib/systemd/system"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (optional) A list containing tags to assign to all resources | `list(string)` | <pre>[<br/>  "vault"<br/>]</pre> | no |
+| <a name="input_vault_audit_disk_size"></a> [vault\_audit\_disk\_size](#input\_vault\_audit\_disk\_size) | (optional) The disk size (GB) to use to create the Vault audit log disk | `number` | `50` | no |
+| <a name="input_vault_audit_disk_type"></a> [vault\_audit\_disk\_type](#input\_vault\_audit\_disk\_type) | (optional) The disk type to use to create the Vault audit log disk | `string` | `"pd-balanced"` | no |
+| <a name="input_vault_custom_role"></a> [vault\_custom\_role](#input\_vault\_custom\_role) | (optional) List of permissions for the Vault custom role | `list(string)` | <pre>[<br/>  "compute.zones.list",<br/>  "compute.instances.list"<br/>]</pre> | no |
+| <a name="input_vault_data_disk_size"></a> [vault\_data\_disk\_size](#input\_vault\_data\_disk\_size) | (optional) The disk size (GB) to use to create the Vault data disk | `number` | `100` | no |
+| <a name="input_vault_data_disk_type"></a> [vault\_data\_disk\_type](#input\_vault\_data\_disk\_type) | (optional) The disk type to use to create the Vault data disk | `string` | `"pd-ssd"` | no |
+| <a name="input_vault_default_lease_ttl_duration"></a> [vault\_default\_lease\_ttl\_duration](#input\_vault\_default\_lease\_ttl\_duration) | The default lease TTL expressed as a time duration in hours, minutes and/or seconds (e.g. `4h30m10s`) | `string` | `"1h"` | no |
+| <a name="input_vault_dir_bin"></a> [vault\_dir\_bin](#input\_vault\_dir\_bin) | Path to install Vault Enterprise binary | `string` | `"/usr/bin"` | no |
+| <a name="input_vault_dir_config"></a> [vault\_dir\_config](#input\_vault\_dir\_config) | Path to install Vault Enterprise binary | `string` | `"/etc/vault.d"` | no |
+| <a name="input_vault_dir_home"></a> [vault\_dir\_home](#input\_vault\_dir\_home) | Path to hold data, plugins and license directories | `string` | `"/opt/vault"` | no |
+| <a name="input_vault_dir_logs"></a> [vault\_dir\_logs](#input\_vault\_dir\_logs) | Path to hold Vault file audit device logs | `string` | `"/var/log/vault"` | no |
 | <a name="input_vault_disable_mlock"></a> [vault\_disable\_mlock](#input\_vault\_disable\_mlock) | (optional) Disable the server from executing the `mlock` syscall | `bool` | `true` | no |
 | <a name="input_vault_enable_ui"></a> [vault\_enable\_ui](#input\_vault\_enable\_ui) | (optional) Enable the Vault UI | `bool` | `true` | no |
-| <a name="input_vault_health_endpoints"></a> [vault\_health\_endpoints](#input\_vault\_health\_endpoints) | (optional) The status codes to return when querying Vault's sys/health endpoint | `map(string)` | <pre>{<br>  "activecode": "200",<br>  "drsecondarycode": "472",<br>  "performancestandbycode": "473",<br>  "perfstandbyok": "true",<br>  "sealedcode": "503",<br>  "standbycode": "429",<br>  "standbyok": "true",<br>  "uninitcode": "501"<br>}</pre> | no |
-| <a name="input_vault_home_directory"></a> [vault\_home\_directory](#input\_vault\_home\_directory) | (optional) The home directory for the Vault user | `string` | `"/etc/vault.d"` | no |
-| <a name="input_vault_leader_tls_servername"></a> [vault\_leader\_tls\_servername](#input\_vault\_leader\_tls\_servername) | (optional) TLS servername to use when trying to connect to the Raft cluster with HTTPS | `string` | `null` | no |
-| <a name="input_vault_license_secret"></a> [vault\_license\_secret](#input\_vault\_license\_secret) | (optional) The ARN of the license secret in AWS Secrets Manager | `string` | `null` | no |
-| <a name="input_vault_private_key_secret"></a> [vault\_private\_key\_secret](#input\_vault\_private\_key\_secret) | (required) The name of the signed certificate's private key secret in Secret Manager | `string` | n/a | yes |
-| <a name="input_vault_seal_type"></a> [vault\_seal\_type](#input\_vault\_seal\_type) | (optional) The seal type to use for Vault | `string` | `"shamir"` | no |
-| <a name="input_vault_signed_cert_secret"></a> [vault\_signed\_cert\_secret](#input\_vault\_signed\_cert\_secret) | (required) The name of the signed certificate secret in Secret Manager | `string` | n/a | yes |
-| <a name="input_vault_systemd_directory"></a> [vault\_systemd\_directory](#input\_vault\_systemd\_directory) | (optional) The directory for the systemd unit | `string` | `"/lib/systemd/system"` | no |
-| <a name="input_vault_tls_disable_client_certs"></a> [vault\_tls\_disable\_client\_certs](#input\_vault\_tls\_disable\_client\_certs) | (optional) Disable client authentication for the Vault listener | `bool` | `true` | no |
+| <a name="input_vault_group_name"></a> [vault\_group\_name](#input\_vault\_group\_name) | Name of group to own Vault files and processes | `string` | `"vault"` | no |
+| <a name="input_vault_health_endpoints"></a> [vault\_health\_endpoints](#input\_vault\_health\_endpoints) | (optional) The status codes to return when querying Vault's sys/health endpoint | `map(string)` | <pre>{<br/>  "activecode": "200",<br/>  "drsecondarycode": "472",<br/>  "performancestandbycode": "473",<br/>  "perfstandbyok": "true",<br/>  "sealedcode": "503",<br/>  "standbycode": "429",<br/>  "standbyok": "true",<br/>  "uninitcode": "200"<br/>}</pre> | no |
+| <a name="input_vault_kms_custom_role"></a> [vault\_kms\_custom\_role](#input\_vault\_kms\_custom\_role) | (optional) List of permissions for the Vault KMS custom role | `list(string)` | <pre>[<br/>  "cloudkms.cryptoKeys.get",<br/>  "cloudkms.cryptoKeyVersions.useToDecrypt",<br/>  "cloudkms.cryptoKeyVersions.useToEncrypt"<br/>]</pre> | no |
+| <a name="input_vault_max_lease_ttl_duration"></a> [vault\_max\_lease\_ttl\_duration](#input\_vault\_max\_lease\_ttl\_duration) | The max lease TTL expressed as a time duration in hours, minutes and/or seconds (e.g. `4h30m10s`) | `string` | `"768h"` | no |
+| <a name="input_vault_plugin_urls"></a> [vault\_plugin\_urls](#input\_vault\_plugin\_urls) | (optional list) List of Vault plugin fully qualified URLs (example ["https://releases.hashicorp.com/terraform-provider-oraclepaas/1.5.3/terraform-provider-oraclepaas_1.5.3_linux_amd64.zip"] for deployment to Vault plugins directory) | `list(string)` | `[]` | no |
+| <a name="input_vault_port_api"></a> [vault\_port\_api](#input\_vault\_port\_api) | TCP port for Vault API listener | `number` | `8200` | no |
+| <a name="input_vault_port_cluster"></a> [vault\_port\_cluster](#input\_vault\_port\_cluster) | TCP port for Vault cluster address | `number` | `8201` | no |
+| <a name="input_vault_seal_type"></a> [vault\_seal\_type](#input\_vault\_seal\_type) | (optional) The seal type to use for Vault | `string` | `"gcpckms"` | no |
+| <a name="input_vault_tls_disable_client_certs"></a> [vault\_tls\_disable\_client\_certs](#input\_vault\_tls\_disable\_client\_certs) | Disable client authentication for the Vault listener. Must be enabled when tls auth method is used. | `bool` | `true` | no |
 | <a name="input_vault_tls_require_and_verify_client_cert"></a> [vault\_tls\_require\_and\_verify\_client\_cert](#input\_vault\_tls\_require\_and\_verify\_client\_cert) | (optional) Require a client to present a client certificate that validates against system CAs | `bool` | `false` | no |
 | <a name="input_vault_user_data_template"></a> [vault\_user\_data\_template](#input\_vault\_user\_data\_template) | (optional) Alternative template file to provide for instance template metadata script. place the file in your local `./templates folder` no path required | `string` | `"google_vault_metadata.sh.tpl"` | no |
-| <a name="input_vault_version"></a> [vault\_version](#input\_vault\_version) | (optional) The version of Vault to use | `string` | `"1.16.0+ent"` | no |
+| <a name="input_vault_user_name"></a> [vault\_user\_name](#input\_vault\_user\_name) | Name of system user to own Vault files and processes | `string` | `"vault"` | no |
+| <a name="input_vault_version"></a> [vault\_version](#input\_vault\_version) | (optional) The version of Vault to use | `string` | `"1.17.3+ent"` | no |
 
 ## Outputs
 
@@ -178,5 +194,6 @@ No modules.
 |------|-------------|
 | <a name="output_loadbalancer_ip"></a> [loadbalancer\_ip](#output\_loadbalancer\_ip) | The external ip address of the forwarding rule. |
 | <a name="output_user_data_template"></a> [user\_data\_template](#output\_user\_data\_template) | n/a |
-| <a name="output_vault_data"></a> [vault\_data](#output\_vault\_data) | Vault utility output for first Vault connection and init. |
+| <a name="output_vault_cli_config"></a> [vault\_cli\_config](#output\_vault\_cli\_config) | Environment variables to configure the Vault CLI |
+| <a name="output_zones"></a> [zones](#output\_zones) | n/a |
 <!-- END_TF_DOCS -->

--- a/examples/default/terraform.auto.tfvars.example
+++ b/examples/default/terraform.auto.tfvars.example
@@ -9,14 +9,17 @@ compute_image_family    = "ubuntu-2204-lts"
 compute_image_project   = "ubuntu-os-cloud"
 create_cloud_dns_record = false
 debug                   = false
-disk_size               = 100
-disk_type               = "pd-ssd"
+vault_data_disk_size    = 100
+vault_data_disk_type    = "pd-ssd"
+vault_audit_disk_size   = 100
+vault_audit_disk_type   = "pd-ssd"
 enable_auto_healing     = false
 enable_iap              = true
 gcp_kms_crypto_key      = ""
 gcp_kms_key_ring        = ""
 gcp_kms_project         = ""
 gcp_kms_region          = ""
+vault_snapshot_gcs_bucket_name = null
 google_service_account_iam_roles = [
   "roles/compute.viewer",
   "roles/secretmanager.secretAccessor",
@@ -28,24 +31,18 @@ health_timeout             = 15
 initial_auto_healing_delay = 1200
 load_balancing_scheme      = "INTERNAL"
 machine_type               = "e2-standard-2"
-metadata                   = ""
+metadata                   = { app = "vault" }
 network                    = "default"
 network_project_id         = ""
 network_region             = ""
 node_count                 = 6
 project_id                 = ""
 region                     = "us-central1"
-skip_install_tools         = false
 subnetwork                 = "default"
 tags = [
   "vault"
 ]
-vault_api_port         = "8200"
-vault_backend_storage  = "integrated"
-vault_bin_directory    = "/usr/bin"
-vault_ca_bundle_secret = ""
-vault_cluster_port     = "8201"
-vault_data_directory   = "/opt/vault"
+
 vault_disable_mlock    = true
 vault_enable_ui        = true
 vault_health_endpoints = {
@@ -58,15 +55,15 @@ vault_health_endpoints = {
   "standbyok": "true",
   "uninitcode": "501"
 }
-vault_home_directory                     = "/etc/vault.d"
-vault_leader_tls_servername              = ""
-vault_license_secret                     = ""
+
 vault_plugin_urls                        = []
-vault_private_key_secret                 = ""
 vault_seal_type                          = "shamir"
-vault_signed_cert_secret                 = ""
-vault_systemd_directory                  = "/lib/systemd/system"
 vault_tls_disable_client_certs           = true
 vault_tls_require_and_verify_client_cert = false
 vault_user_data_template                 = "google_vault_metadata.sh.tpl"
-vault_version                            = "1.16.0+ent"
+vault_version                            = "1.18.3+ent"
+
+vault_license_sm_secret_name       = "vault-license"
+vault_tls_cert_sm_secret_name      = "vault-cert-file"
+vault_tls_privkey_sm_secret_name   = "vault-key-file"
+vault_tls_ca_bundle_sm_secret_name = "vault-ca-file"

--- a/examples/default/terraform.auto.tfvars.example
+++ b/examples/default/terraform.auto.tfvars.example
@@ -20,7 +20,8 @@ gcp_kms_region          = ""
 google_service_account_iam_roles = [
   "roles/compute.viewer",
   "roles/secretmanager.secretAccessor",
-  "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  "roles/logging.logWriter",
+  "roles/monitoring.metricWriter"
 ]
 health_check_interval      = 30
 health_timeout             = 15

--- a/examples/default/variables.tf
+++ b/examples/default/variables.tf
@@ -420,7 +420,6 @@ variable "google_service_account_iam_roles" {
   type        = list(string)
   description = "(optional) List of IAM roles to give to the Vault service account"
   default = [
-    "roles/compute.viewer",
     "roles/secretmanager.secretAccessor",
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
@@ -434,6 +433,16 @@ variable "vault_kms_custom_role" {
     "cloudkms.cryptoKeys.get",
     "cloudkms.cryptoKeyVersions.useToDecrypt",
     "cloudkms.cryptoKeyVersions.useToEncrypt",
+  ]
+}
+
+variable "vault_custom_role" {
+  description = "(optional) List of permissions for the Vault custom role"
+  type        = list(string)
+  default = [
+    # Auto join
+    "compute.zones.list",
+    "compute.instances.list",
   ]
 }
 

--- a/examples/default/variables.tf
+++ b/examples/default/variables.tf
@@ -422,7 +422,18 @@ variable "google_service_account_iam_roles" {
   default = [
     "roles/compute.viewer",
     "roles/secretmanager.secretAccessor",
-    "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+  ]
+}
+
+variable "vault_kms_custom_role" {
+  description = "(optional) List of permissions for the Vault KMS custom role"
+  type        = list(string)
+  default = [
+    "cloudkms.cryptoKeys.get",
+    "cloudkms.cryptoKeyVersions.useToDecrypt",
+    "cloudkms.cryptoKeyVersions.useToEncrypt",
   ]
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -39,3 +39,16 @@ resource "google_storage_bucket_iam_binding" "snapshots_viewer" {
     google_service_account.vault_sa.member
   ]
 }
+
+resource "google_project_iam_custom_role" "vault_custom_role" {
+  role_id     = "vaultCustomRole"
+  title       = "Vault Custom Role"
+  description = "Custom role for Vault to access GCP resources"
+  permissions = var.vault_custom_role
+}
+
+resource "google_project_iam_member" "vault_custom_role" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.vault_custom_role.name
+  member  = google_service_account.vault_sa.member
+}

--- a/iam.tf
+++ b/iam.tf
@@ -15,7 +15,7 @@ resource "google_project_iam_member" "vault_iam" {
 
   project = var.project_id
   role    = each.value
-  member  = format("serviceAccount:%s", google_service_account.vault_sa.email)
+  member  = google_service_account.vault_sa.member
 }
 
 resource "google_storage_bucket_iam_binding" "snapshots_creator" {
@@ -25,7 +25,7 @@ resource "google_storage_bucket_iam_binding" "snapshots_creator" {
   role   = "roles/storage.objectCreator"
 
   members = [
-    format("serviceAccount:%s", google_service_account.vault_sa.email)
+    google_service_account.vault_sa.member
   ]
 }
 
@@ -36,6 +36,6 @@ resource "google_storage_bucket_iam_binding" "snapshots_viewer" {
   role   = "roles/storage.objectViewer"
 
   members = [
-    format("serviceAccount:%s", google_service_account.vault_sa.email)
+    google_service_account.vault_sa.member
   ]
 }

--- a/kms.tf
+++ b/kms.tf
@@ -25,7 +25,7 @@ resource "google_project_iam_member" "vault_iam_kms" {
 
   project = var.gcp_kms_project
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member  = format("serviceAccount:%s", google_service_account.vault_sa.email)
+  member  = google_service_account.vault_sa.member
 }
 
 resource "google_kms_crypto_key_iam_member" "vault_key" {
@@ -33,7 +33,7 @@ resource "google_kms_crypto_key_iam_member" "vault_key" {
 
   crypto_key_id = data.google_kms_crypto_key.vault_key[0].id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:${google_service_account.vault_sa.email}"
+  member        = google_service_account.vault_sa.member
 }
 resource "google_kms_key_ring_iam_binding" "vault_iam_kms_binding" {
   count       = var.gcp_kms_key_ring == null ? 0 : 1
@@ -42,6 +42,6 @@ resource "google_kms_key_ring_iam_binding" "vault_iam_kms_binding" {
   role = "roles/editor"
 
   members = [
-    "serviceAccount:${google_service_account.vault_sa.email}",
+    google_service_account.vault_sa.member,
   ]
 }

--- a/kms.tf
+++ b/kms.tf
@@ -28,20 +28,17 @@ resource "google_project_iam_member" "vault_iam_kms" {
   member  = google_service_account.vault_sa.member
 }
 
+resource "google_project_iam_custom_role" "vault_kms_custom_role" {
+  role_id     = "vaultKmsRole"
+  title       = "Vault KMS CryptoKey Encrypter/Decrypter and Viewer Role"
+  description = "Custom role for Vault to access Cloud KMS Key"
+  permissions = var.vault_kms_custom_role
+}
+
 resource "google_kms_crypto_key_iam_member" "vault_key" {
   count = var.gcp_kms_crypto_key == null ? 0 : 1
 
   crypto_key_id = data.google_kms_crypto_key.vault_key[0].id
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  role          = google_project_iam_custom_role.vault_kms_custom_role.name
   member        = google_service_account.vault_sa.member
-}
-resource "google_kms_key_ring_iam_binding" "vault_iam_kms_binding" {
-  count       = var.gcp_kms_key_ring == null ? 0 : 1
-  key_ring_id = data.google_kms_key_ring.vault[0].id
-  # key_ring_id = "${var.gcloud-project}/${var.keyring_location}/${var.key_ring}"
-  role = "roles/editor"
-
-  members = [
-    google_service_account.vault_sa.member,
-  ]
 }

--- a/kms.tf
+++ b/kms.tf
@@ -29,6 +29,8 @@ resource "google_project_iam_member" "vault_iam_kms" {
 }
 
 resource "google_project_iam_custom_role" "vault_kms_custom_role" {
+  count = var.gcp_kms_crypto_key == null ? 0 : 1
+
   role_id     = "vaultKmsRole"
   title       = "Vault KMS CryptoKey Encrypter/Decrypter and Viewer Role"
   description = "Custom role for Vault to access Cloud KMS Key"
@@ -39,6 +41,6 @@ resource "google_kms_crypto_key_iam_member" "vault_key" {
   count = var.gcp_kms_crypto_key == null ? 0 : 1
 
   crypto_key_id = data.google_kms_crypto_key.vault_key[0].id
-  role          = google_project_iam_custom_role.vault_kms_custom_role.name
+  role          = google_project_iam_custom_role.vault_kms_custom_role[0].name
   member        = google_service_account.vault_sa.member
 }

--- a/variables.tf
+++ b/variables.tf
@@ -420,7 +420,6 @@ variable "google_service_account_iam_roles" {
   type        = list(string)
   description = "(optional) List of IAM roles to give to the Vault service account"
   default = [
-    "roles/compute.viewer",
     "roles/secretmanager.secretAccessor",
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
@@ -434,6 +433,16 @@ variable "vault_kms_custom_role" {
     "cloudkms.cryptoKeys.get",
     "cloudkms.cryptoKeyVersions.useToDecrypt",
     "cloudkms.cryptoKeyVersions.useToEncrypt",
+  ]
+}
+
+variable "vault_custom_role" {
+  description = "(optional) List of permissions for the Vault custom role"
+  type        = list(string)
+  default = [
+    # Auto join
+    "compute.zones.list",
+    "compute.instances.list",
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -422,7 +422,18 @@ variable "google_service_account_iam_roles" {
   default = [
     "roles/compute.viewer",
     "roles/secretmanager.secretAccessor",
-    "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+  ]
+}
+
+variable "vault_kms_custom_role" {
+  description = "(optional) List of permissions for the Vault KMS custom role"
+  type        = list(string)
+  default = [
+    "cloudkms.cryptoKeys.get",
+    "cloudkms.cryptoKeyVersions.useToDecrypt",
+    "cloudkms.cryptoKeyVersions.useToEncrypt",
   ]
 }
 
@@ -477,3 +488,4 @@ variable "health_timeout" {
   description = "(optional) How long, in seconds, to wait before claiming failure"
   default     = 15
 }
+


### PR DESCRIPTION
## Description
- Restrict Cloud KMS access to the minimum permissions needed.
- Add logWriter and metricWriter roles to let Vault send logs and metrics to Cloud Logging and Monitoring.
- Replace `roles/compute.viewer` with a custom role
- Update READMEs

## Related issue
N/A

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
Tested on GCP with Vault Enterprise v1.18.3 Enterprise + Cloud KMS unseal.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional notes
[Add any additional information or context about the PR here]
